### PR TITLE
0.0.4

### DIFF
--- a/picknik_reset_fault_controller/CHANGELOG.rst
+++ b/picknik_reset_fault_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package picknik_reset_fault_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix deprecated realtime_tools header imports (`#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>`_)
+* Contributors: Sebastian Castro
+
 0.0.3 (2023-07-24)
 ------------------
 

--- a/picknik_reset_fault_controller/CHANGELOG.rst
+++ b/picknik_reset_fault_controller/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package picknik_reset_fault_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.0.4 (2025-02-09)
+------------------
 * Fix deprecated realtime_tools header imports (`#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>`_)
 * Contributors: Sebastian Castro
 

--- a/picknik_reset_fault_controller/package.xml
+++ b/picknik_reset_fault_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>picknik_reset_fault_controller</name>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
   <description>
     ROS 2 controller that offers a service to clear faults in a hardware interface
   </description>

--- a/picknik_twist_controller/CHANGELOG.rst
+++ b/picknik_twist_controller/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package picknik_twist_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.0.4 (2025-02-09)
+------------------
 * Fix deprecated realtime_tools header imports (`#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>`_)
 * Contributors: Sebastian Castro
 

--- a/picknik_twist_controller/CHANGELOG.rst
+++ b/picknik_twist_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package picknik_twist_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix deprecated realtime_tools header imports (`#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>`_)
+* Contributors: Sebastian Castro
+
 0.0.3 (2023-07-24)
 ------------------
 * Use Twist not TwistStamped (`#11 <https://github.com/PickNikRobotics/picknik_controllers/issues/11>`_)

--- a/picknik_twist_controller/package.xml
+++ b/picknik_twist_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>picknik_twist_controller</name>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
   <description>Subscribes to twist msg and forwards to hardware</description>
   <maintainer email="lovro.ivanov@gmail.com">lovro</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
This release is needed to unbreak Rolling.

Would be nice to get https://github.com/PickNikRobotics/picknik_controllers/pull/15 merged in as well first, though this doesn't affect the changelog/version as it's just CI.