### PR TITLE
Update upload-artifact action version in reusable-ros-tooling-source-build.yml

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -43,7 +43,7 @@ jobs:
             https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/picknik_controllers.${{ inputs.ros_distro }}.repos?token=${{ secrets.GITHUB_TOKEN }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: colcon-logs-ubuntu-22.04
           path: ros_ws/log

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -45,5 +45,5 @@ jobs:
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v4
         with:
-          name: colcon-logs-ubuntu-22.04
+          name: colcon-logs-ubuntu-24.04
           path: ros_ws/log


### PR DESCRIPTION
Looking at the GitHub actions, I missed one version update.

See e.g. https://github.com/PickNikRobotics/picknik_controllers/actions/runs/13938076836/job/39009742319#step:1:25