### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/picknik_reset_fault_controller/CMakeLists.txt
+++ b/picknik_reset_fault_controller/CMakeLists.txt
@@ -28,8 +28,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+target_link_libraries(${PROJECT_NAME}
+  ${controller_interface_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
+  realtime_tools::realtime_tools
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/picknik_twist_controller/CMakeLists.txt
+++ b/picknik_twist_controller/CMakeLists.txt
@@ -28,8 +28,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+target_link_libraries(${PROJECT_NAME}
+  ${controller_interface_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
+  realtime_tools::realtime_tools
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,


### PR DESCRIPTION
Build is broken this should fix it

https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__picknik_twist_controller__ubuntu_noble_amd64__binary/244/console

FYI @nbbrooks 

We will need a release too when this PR is merged