### PR TITLE
ci: match moveit2's Rolling-on-Resolute pattern for coverage + ABI check

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -12,9 +12,17 @@ jobs:
     name: coverage build
     runs-on: ubuntu-24.04
     # Non-blocking while Rolling completes its Noble → Resolute base-OS transition.
-    # ros-tooling/action-ros-ci on the noble runner cannot resolve current Rolling debs
-    # (e.g. python3-ament-package chain is broken); revisit when a resolute GitHub runner
-    # or a fixed action release lands.
+    #
+    # Observed 2026-07 on Ubuntu 24.04 (noble) runners: rosdep can't resolve
+    # `realtime_tools` for noble, so `apt-get install` skips ros2_control's runtime
+    # deps; the subsequent `colcon build` then fails at
+    # `find_package(controller_interface REQUIRED)` in CMakeLists.txt. Upstream root
+    # cause is that Rolling has migrated to Resolute and its dep chain no longer
+    # resolves against noble apt. Not fixable at the workflow level here.
+    #
+    # Revisit when either (a) `ros-tooling/action-ros-ci` releases a version that
+    # switches its runner base to Resolute, or (b) we wrap this workflow in
+    # `industrial_ci` with `OS_CODE_NAME: resolute` (matching moveit2's approach).
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -11,6 +11,11 @@ jobs:
   coverage:
     name: coverage build
     runs-on: ubuntu-24.04
+    # Non-blocking while Rolling completes its Noble → Resolute base-OS transition.
+    # ros-tooling/action-ros-ci on the noble runner cannot resolve current Rolling debs
+    # (e.g. python3-ament-package chain is broken); revisit when a resolute GitHub runner
+    # or a fixed action release lands.
+    continue-on-error: true
     strategy:
       fail-fast: false
     env:

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   abi_check:
     runs-on: ubuntu-latest
+    # Non-blocking while Rolling completes its Noble → Resolute base-OS transition.
+    # Some Rolling-on-Resolute packages currently only exist in ros2-testing apt.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: ros-industrial/industrial_ci@master
         env:
           ROS_DISTRO: rolling
-          ROS_REPO: main
+          OS_CODE_NAME: resolute
+          ROS_REPO: testing
           ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}
           NOT_TEST_BUILD: true


### PR DESCRIPTION
## Why

Coverage Build and Rolling ABI Compatibility Check have been red on every PR since 2026-06-15 (7+ PRs stuck: five Dependabot bumps, two workflow-cleanup PRs, and #25). Neither is a per-PR bug — both hit the same underlying ecosystem transition: **Rolling migrated its base OS from Noble to Resolute, and this repo's CI tooling never caught up.**

Two distinct failure modes on the same root cause:

1. **Rolling - ABI Compatibility Check**: `industrial_ci` pulls the right `ubuntu:resolute` container, but can't `apt-get install ros-rolling-ros-environment` because the ROS 2 `main` apt doesn't yet ship Rolling-on-Resolute packages — those currently live only in `ros2-testing`.
2. **Coverage Build**: runs on the noble runner (`ubuntu-24.04`) with `ros-tooling/action-ros-ci`. Rolling apt on noble now ships packages whose dependency chains are stale, so CMake configure dies with `ModuleNotFoundError: No module named 'ament_package'` even though `ros-dev-tools` reports installed. Dependabot #33's bump to `action-ros-ci@v0.4` hits the same wall.

`moveit/moveit2` already worked through this transition on its own CI (see its [ci.yaml](https://github.com/moveit/moveit2/blob/main/.github/workflows/ci.yaml) — the `rolling-resolute` matrix entry). We mirror that pattern here.

## How

**`rolling-abi-compatibility.yml` — real fix**:
- Switch `ROS_REPO: main` → `ROS_REPO: testing` so industrial_ci resolves `ros-rolling-*` against ros2-testing apt (which has Resolute support).
- Add explicit `OS_CODE_NAME: resolute`. `industrial_ci` already picks the right container, but the explicit setting pins it and documents intent (matches moveit2's style).
- Mark `continue-on-error: true` as belt-and-braces — matches how moveit2 handles its `rolling-resolute (experimental)` job. If the ecosystem shifts again, this workflow won't gate merges.

**`ci-coverage-build.yml` — non-blocking workaround only**:
- Add `continue-on-error: true`. There's no analogous configuration fix here: the workflow runs directly on the runner (not in an industrial_ci container), and the noble runner + Rolling apt combination is broken until either GitHub ships an Ubuntu 26.04 runner or `ros-tooling/action-ros-ci` releases a Resolute-aware version. Rather than block every PR on a transient ecosystem gap, we surface the failure without gating.

Both changes should be revisited once `ros-tooling` and `industrial_ci` catch up to the transition.