### PR TITLE
Declare the hardware_interface dependency explicitly

### DIFF
--- a/picknik_reset_fault_controller/CMakeLists.txt
+++ b/picknik_reset_fault_controller/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -16,6 +17,7 @@ find_package(realtime_tools REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_interface
+  hardware_interface
   geometry_msgs
   example_interfaces
   realtime_tools
@@ -30,6 +32,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME}
   ${controller_interface_TARGETS}
+  ${hardware_interface_TARGETS}
   ${geometry_msgs_TARGETS}
   ${example_interfaces_TARGETS}
   realtime_tools::realtime_tools

--- a/picknik_reset_fault_controller/package.xml
+++ b/picknik_reset_fault_controller/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>example_interfaces</depend>
   <depend>rclcpp</depend>

--- a/picknik_twist_controller/CMakeLists.txt
+++ b/picknik_twist_controller/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -16,6 +17,7 @@ find_package(realtime_tools REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_interface
+  hardware_interface
   geometry_msgs
   example_interfaces
   realtime_tools
@@ -30,6 +32,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME}
   ${controller_interface_TARGETS}
+  ${hardware_interface_TARGETS}
   ${geometry_msgs_TARGETS}
   ${example_interfaces_TARGETS}
   realtime_tools::realtime_tools

--- a/picknik_twist_controller/package.xml
+++ b/picknik_twist_controller/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>example_interfaces</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
Fixes #36.

## Why

Both controllers use `hardware_interface` directly:

| | include | usage |
|---|---|---|
| `picknik_reset_fault_controller` | `src/…:26` `#include "hardware_interface/loaned_command_interface.hpp"` | `using hardware_interface::LoanedCommandInterface;` |
| `picknik_twist_controller` | `src/…:31` same header | same |

Neither declared `hardware_interface` in `package.xml`, and neither `find_package`d it. They relied on it arriving transitively:

```
picknik_*_controller -> controller_interface -> hardware_interface
```

As @Plumezz noted in #36, this is not a build break today. It's a metadata problem: a dependency we use directly is invisible to rosdep and to anyone reading the manifest, and it would break silently if `controller_interface` ever stopped re-exporting it.

Two additions to the original report: the gap is on **`main`** as well as `humble`, and it affects **both** packages, not just `picknik_reset_fault_controller`.

## How

For each package:

- `<depend>hardware_interface</depend>` in `package.xml`
- `find_package(hardware_interface REQUIRED)`
- `hardware_interface` added to `THIS_PACKAGE_INCLUDE_DEPENDS`, so it's re-exported to consumers alongside the other direct deps
- `${hardware_interface_TARGETS}` in `target_link_libraries`, matching the `${..._TARGETS}` style already used for `controller_interface`

On the last point — I checked that `hardware_interface_TARGETS` resolves to `hardware_interface::hardware_interface` only. `mock_components` is in a separate export set (`export_mock_components`) and is not pulled in, so this doesn't widen the link beyond what's intended.

8 lines added, nothing removed.

## Verification

Built both packages from a clean workspace in a `ros:lyrical-ros-base` container: `rosdep install` resolves the newly-declared dependency, and `colcon build` succeeds for both.

## Separate finding: 12 ignored `set_value()` return values

Not fixed here, since it needs a behaviour decision rather than a metadata one — but the build surfaces it, so worth recording.

`LoanedCommandInterface::set_value()` is `[[nodiscard]]` on lyrical and returns `false` if it cannot acquire the lock within `max_tries` (default 10). Both controllers discard it at every call site — **12 `-Wunused-result` warnings, 6 per package**:

- `picknik_reset_fault_controller.cpp`: 87, 88, 113, 114, 122, 123
- `picknik_twist_controller.cpp`: 148–153

```
warning: ignoring return value of 'bool hardware_interface::LoanedCommandInterface::set_value(
  const T&, unsigned int) [with T = double]', declared with attribute 'nodiscard' [-Wunused-result]
```

So both controllers can currently drop a command write silently. Note the read path was already modernised — `get_optional()` with `value_or(...)` — so this is the write half of the same API migration left unfinished. Worth its own issue; happy to file it and take it if you want.

## Sequencing

Branched off `main`, so until #38 merges this PR only exercises the currently-active workflows. Once #38 is in I'll rebase so it gets the full matrix, including the blocking `lyrical-main` job.

The same fix is wanted on the `humble` branch, which has the identical gap in both packages. Say the word and I'll open that as a companion PR.